### PR TITLE
Support Catalyst apps 

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -38,9 +38,10 @@ function getAppNamesToIconPaths(parsedDockData) {
     for (const parsedAppData of persistentApps) {
         const appName = parsedAppData.dict[0].string[1];
         const appDirectoryUrl = parsedAppData.dict[0].dict?.[0].string[0];
+
         if (appDirectoryUrl && isAppNameAllowed(appName)) {
             const appDirectory = url.fileURLToPath(appDirectoryUrl)
-            result[appName] = getIconPath(appDirectory);
+            result[appName] = getIconPath(appDirectory) || getIconPathForCatalystApp(appDirectory);
         }
     }
     return result;
@@ -75,6 +76,29 @@ function getIconPath(appDirectory) {
         }
     }
     return null;
+}
+
+/**
+ * Returns path to icon for a Catalyst app
+ * @param appDirectory
+ * @return {string|null}
+ */
+function getIconPathForCatalystApp(appDirectory)  {
+    const bundleDirectory = path.join(appDirectory, 'Wrapper', path.basename(appDirectory));
+    if (!fs.pathExistsSync(bundleDirectory)) return null;
+    let largestIcon = {size: 0, fileName: null}
+    fs.readdirSync(bundleDirectory).forEach(fileName => {
+        // 'AppIcon60x60@2x.png' -> groups: { size: '60' }
+        // 'AppIcon76x76@2x~ipad.png' -> groups: { size: '76' }
+        const match = fileName.match(/AppIcon(?<size>\d+)x\d+.*.png/);
+        if (match && match.groups.size && parseInt(match.groups.size) > largestIcon.size) {
+            largestIcon = {
+                size: match.groups.size,
+                fileName: path.join(bundleDirectory, fileName)
+            }
+        }
+    })
+    return largestIcon.fileName;
 }
 
 /**


### PR DESCRIPTION
This PR lives on top of #9, so leaving this as a draft while #9 is open. Fixes #8.



Caveats:
1. The catalyst apps don't include `icns` file, so the icns2png is a NOOP and copies the file from the app's bundle directory to the local temp directory. I chose to leave it as is to add minimal changes to the existing workflow you may have.
2. The AppIcon file is square, as compared to the `icns` files with standard apple rounded corners. If you are using a third-party solution to rounding corners on the front end, this won't matter. Otherwise, it would require additional processing to convert the square app icon to a nicer one with rounded corners.