### PR TITLE
Gracefully handle empty docks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import child_process from 'child_process';
-import {getDockContents} from "./utils.js";
+import {scanDockAndBringToWebApp} from "./utils.js";
 
 // Entry point for the Dockhunt CLI
 
@@ -21,5 +21,5 @@ child_process.exec('defaults export com.apple.dock -', (error, stdout, stderr) =
     }
 
 
-    getDockContents(stdout);
+    scanDockAndBringToWebApp(stdout);
 })

--- a/utils.js
+++ b/utils.js
@@ -130,7 +130,7 @@ export function icns2png(appName, icnsPath, outputDir) {
     });
 }
 
-export async function getDockContents(dockXmlPlist) {
+export async function scanDockAndBringToWebApp(dockXmlPlist) {
     if (!dockXmlPlist.match(/<!DOCTYPE plist/g)) {
         throw 'Dock data appears to be invalid. Expected: Apple plist XML.';
     }


### PR DESCRIPTION
If the CLI finds no apps in the dock, don't proceed to do anything substantive. Inform the user and be done.

In the future we might want to support empty docks in the web app.