### PR TITLE
WIP: Improves plist parsing for a better/easier development experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dockhunt",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dockhunt",
-      "version": "1.0.11",
+      "version": "1.0.17",
       "license": "ISC",
       "os": [
         "darwin"
@@ -15,6 +15,7 @@
         "fs-extra": "^11.1.0",
         "node-fetch": "^3.3.0",
         "open": "^8.4.0",
+        "plist": "^3.0.6",
         "xml2js": "^0.4.23"
       },
       "bin": {
@@ -1511,6 +1512,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
+      "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
+      "dependencies": {
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/plist/node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -3239,6 +3260,22 @@
           "requires": {
             "whatwg-url": "^5.0.0"
           }
+        }
+      }
+    },
+    "plist": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
+      "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
+      "requires": {
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "15.1.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+          "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fs-extra": "^11.1.0",
     "node-fetch": "^3.3.0",
     "open": "^8.4.0",
+    "plist": "^3.0.6",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {


### PR DESCRIPTION
**First of all, awesome project!**

While reading the source code, I found a little bit tricky to understand where the app attributes were. Imagining a scenario where a new attribute needs to be used for some upcoming feature, I think this small change will make things a lot easier.

**_Important note: There is a small optional change at the `getAppNamesWithIconPaths` function. Where only `file-tile` items will be used, leaving out dock spacers._**

The idea is to parse the Apple's Property list using the extremely popular [npm package: plist](https://www.npmjs.com/package/plist)
Here is a screenshot of how the parsed xml looks like:
- Main object:
![CleanShot 2023-02-04 at 13 58 32@2x](https://user-images.githubusercontent.com/19212953/216779817-dbfbd3b7-d505-423c-8df3-0af6500a0e19.png)
- Persistent apps:
![CleanShot 2023-02-04 at 13 59 13@2x](https://user-images.githubusercontent.com/19212953/216779853-b810b57e-ed20-4d4a-9685-352c24175f43.png)

